### PR TITLE
Add support for Django 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Changes we're making en route to version 2.0. When we cut a release, this
 section will form the changelog for v2.0.
 
+- Add support for Django 2.0 ([#8](https://github.com/azavea/grout/pull/8))
 - Removed external `djsonb` dependency and moved its lookup logic into
   Grout core ([#7](https://github.com/azavea/grout/pull/7)
 - Removed extraneous location fields from the `Record` data model (

--- a/grout/migrations/0001_initial.py
+++ b/grout/migrations/0001_initial.py
@@ -60,7 +60,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='record',
             name='schema_id',
-            field=models.ForeignKey(to='grout.RecordSchema'),
+            field=models.ForeignKey(to='grout.RecordSchema', on_delete=models.CASCADE),
         ),
         migrations.AlterUniqueTogether(
             name='itemschema',

--- a/grout/migrations/0006_auto_20150424_1857.py
+++ b/grout/migrations/0006_auto_20150424_1857.py
@@ -49,6 +49,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='boundarypolygon',
             name='boundary',
-            field=models.ForeignKey(related_name='polygons', to='grout.Boundary', null=True),
+            field=models.ForeignKey(related_name='polygons', to='grout.Boundary', null=True, on_delete=models.CASCADE),
         ),
     ]

--- a/grout/migrations/0007_auto_20150427_2114.py
+++ b/grout/migrations/0007_auto_20150427_2114.py
@@ -14,11 +14,11 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='itemschema',
             name='next_version',
-            field=models.OneToOneField(related_name='previous_version', null=True, to='grout.ItemSchema'),
+            field=models.OneToOneField(related_name='previous_version', null=True, to='grout.ItemSchema', on_delete=models.CASCADE),
         ),
         migrations.AddField(
             model_name='recordschema',
             name='next_version',
-            field=models.OneToOneField(related_name='previous_version', null=True, to='grout.RecordSchema'),
+            field=models.OneToOneField(related_name='previous_version', null=True, to='grout.RecordSchema', on_delete=models.CASCADE),
         ),
     ]

--- a/grout/migrations/0009_auto_20150429_1627.py
+++ b/grout/migrations/0009_auto_20150429_1627.py
@@ -14,11 +14,11 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='itemschema',
             name='next_version',
-            field=models.OneToOneField(related_name='previous_version', null=True, editable=False, to='grout.ItemSchema'),
+            field=models.OneToOneField(related_name='previous_version', null=True, editable=False, to='grout.ItemSchema', on_delete=models.CASCADE),
         ),
         migrations.AlterField(
             model_name='recordschema',
             name='next_version',
-            field=models.OneToOneField(related_name='previous_version', null=True, editable=False, to='grout.RecordSchema'),
+            field=models.OneToOneField(related_name='previous_version', null=True, editable=False, to='grout.RecordSchema', on_delete=models.CASCADE),
         ),
     ]

--- a/grout/migrations/0011_auto_20150505_1941.py
+++ b/grout/migrations/0011_auto_20150505_1941.py
@@ -41,7 +41,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='recordschema',
             name='record_type',
-            field=models.ForeignKey(related_name='schemas', to='grout.RecordType'),
+            field=models.ForeignKey(related_name='schemas', to='grout.RecordType', on_delete=models.CASCADE),
         ),
         migrations.AlterUniqueTogether(
             name='recordschema',

--- a/grout/models.py
+++ b/grout/models.py
@@ -28,7 +28,7 @@ class SchemaModel(GroutModel):
     version = models.PositiveIntegerField()
     schema = JSONField()
     next_version = models.OneToOneField('self', related_name='previous_version', null=True,
-                                        editable=False)
+                                        editable=False, on_delete=models.CASCADE)
 
     class Meta(object):
         abstract = True
@@ -60,7 +60,7 @@ class Record(GroutModel):
     geom = models.PointField(srid=settings.GROUT['SRID'])
     location_text = models.CharField(max_length=200, null=True, blank=True)
 
-    schema = models.ForeignKey('RecordSchema')
+    schema = models.ForeignKey('RecordSchema', on_delete=models.CASCADE)
     data = JSONField()
 
     archived = models.BooleanField(default=False)
@@ -83,7 +83,9 @@ class RecordType(GroutModel):
 
 class RecordSchema(SchemaModel):
     """Schemas for spatiotemporal records"""
-    record_type = models.ForeignKey('RecordType', related_name='schemas')
+    record_type = models.ForeignKey('RecordType',
+                                    related_name='schemas',
+                                    on_delete=models.CASCADE)
 
     class Meta(object):
         unique_together = (('record_type', 'version'),)
@@ -161,6 +163,9 @@ class Boundary(GroutModel):
 class BoundaryPolygon(GroutModel):
     """ Individual boundaries and associated data for each geom in a BoundaryUpload """
 
-    boundary = models.ForeignKey('Boundary', related_name='polygons', null=True)
+    boundary = models.ForeignKey('Boundary',
+                                 related_name='polygons',
+                                 null=True,
+                                 on_delete=models.CASCADE)
     data = JSONField()
     geom = models.MultiPolygonField(srid=settings.GROUT['SRID'])

--- a/grout/urls.py
+++ b/grout/urls.py
@@ -15,7 +15,7 @@ router.register('recordschemas', views.RecordSchemaViewSet)
 router.register('recordtypes', views.RecordTypeViewSet)
 
 urlpatterns = [
-    url(r'^admin/', include(admin.site.urls)),
+    url(r'^admin/', admin.site.urls),
     url(r'^api/', include(router.urls)),
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     packages=find_packages(exclude=['tests']),
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
     install_requires=[
-        'Django ~=1.11',
+        'Django >=1.11',
         'djangorestframework >=3.8.0',
         'djangorestframework-gis >=0.8.1',
         'django-filter >=1.1.0,<2.0.0',

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     packages=find_packages(exclude=['tests']),
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
     install_requires=[
-        'Django >=1.11',
+        'Django >=1.11, <=2.1',
         'djangorestframework >=3.8.0',
         'djangorestframework-gis >=0.8.1',
         'django-filter >=1.1.0,<2.0.0',

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,7 +1,7 @@
 import os
 import json
 
-from django.core.urlresolvers import reverse
+import django
 from django.contrib.gis.geos import Polygon, LinearRing, MultiPolygon
 
 from rest_framework import status
@@ -10,6 +10,10 @@ from tests.api_test_case import GroutAPITestCase
 from grout.models import (Boundary, BoundaryPolygon,
                           RecordSchema, RecordType)
 
+if django.VERSION < (2, 0):
+    from django.core.urlresolvers import reverse
+else:
+    from django.urls import reverse
 
 class RecordSchemaViewTestCase(GroutAPITestCase):
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,12 @@
 [tox]
 envlist =
         {py27,py34,py35,py36}-django111,
+        {py34,py35,py36}-django20,
 
 [testenv]
 deps =
         django111: Django>=1.11,<2.0
+        django20: Django>=2.0,<2.1
         mock
 
 commands = python run_tests.py


### PR DESCRIPTION
# Overview

This PR adds support for Django 2.0.

## Notes

- This PR branches off of #7.
- Initially we [hoped to support unreleased development versions of Django](https://github.com/azavea/grout-2018-fellowship/issues/27) in order to stay ahead of the curve. However, as outlined in that link, we can only support Django 2.0 for now because of a dependency conflict between Python 2 and django-filter. 

## Testing

Travis will run unit tests for all supported versions of Python and Django. To run them locally:

```bash
./scripts/test app
```

Note that this will install virtualenvs for every version of Python and Django in the support matrix. If you'd like to remove virtualenvs after you're done, make sure to run `sudo rm -Rf .tox` in the project directory.

Closes https://github.com/azavea/grout-2018-fellowship/issues/27.

