### PR TITLE
Address unhandled exceptions filtering with non-ASCII values

### DIFF
--- a/grout/lookups.py
+++ b/grout/lookups.py
@@ -72,6 +72,24 @@ class FilterTree(object):
             rules = rules + self.get_rules(val, current_path + [path])
         return rules
 
+    @staticmethod
+    def split_search_pattern(pattern):
+        # Split pattern word by word, but make sure to keep quoted words together
+        # Regex to match quoted substrings from https://stackoverflow.com/a/5696141
+        word_regex =  r'({})'.format(
+            '|'.join([
+                # Match groups of words in double quotes (Allowing for escaping)
+                r'"[^"\\]*(?:\\.[^"\\]*)*"',
+                # Match groups of words in single quotes (Allowing for escaping)
+                r"'[^'\\]*(?:\\.[^'\\]*)*'",
+                # Match all unquoted words individually
+                '[\S]+'
+            ])
+        )
+        matches = re.findall(word_regex, pattern)
+        # The regex matches the bounding quotes in each result, so we want to trim them off
+        return [match.strip('\'"') for match in matches]
+
     def sql(self):
         """
         Produce output that can be compiled into SQL by Django and psycopg2.
@@ -100,22 +118,8 @@ class FilterTree(object):
 
             # The check on 'pattern' here allows us to apply a pattern filter on top of others
             if 'pattern' in rule:
-                # Filter word by word individually, but make sure to keep quoted words together
-                # Regex to match quoted substrings from https://stackoverflow.com/a/5696141:
-                # /"[^"\\]*(?:\\.[^"\\]*)*"/g
-                word_regex =  r'({})'.format(
-                    '|'.join([
-                        # Match groups of words in double quotes (Allowing for escaping)
-                        '\\"[^\\"\\\\]*(?:\\\\.[^\\"\\\\]*)*\\"',
-                        # Match groups of words in single quotes (Allowing for escaping)
-                        '\\\'[^\\\'\\\\]*(?:\\\\.[^\\\'\\\\]*)*\\\'',
-                        # Match all unquoted words individually
-                        '[\S]+'
-                    ])
-                )
                 match_multiple = (rule['_rule_type'] == 'containment_multiple')
-                for pattern in re.findall(word_regex, rule['pattern']):
-                    pattern = pattern.strip('\'"')
+                for pattern in self.split_search_pattern(rule['pattern']):
                     sql_tuple = FilterTree.text_similarity_filter(path, pattern, match_multiple)
                     # add to the list of rules generated for this pattern (one per field)
                     patterns.setdefault(pattern, []).append(sql_tuple)

--- a/grout/lookups.py
+++ b/grout/lookups.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 import json
 import re
 

--- a/tests/jsonb_field_testing/tests.py
+++ b/tests/jsonb_field_testing/tests.py
@@ -409,10 +409,34 @@ class JsonBFilterTests(TestCase):
         val = FilterTree.text_similarity_filter(['root', 'key'], '✓', path_multiple=True)
         self.assertIsNotNone(val)
 
-    def test_unicode_search(self):
+    def test_unicode_search_value(self):
+        """Ensure that unicode values can be filtered for successfully."""
+        record = JsonBModel.objects.create(data={"key": "'Verified ✓'"})
+
+        filt = {'key': {'_rule_type': 'containment', 'pattern': '✓'}}
+        query = JsonBModel.objects.filter(data__jsonb=filt)
+        self.assertEqual(list(query), [record])
+
+    def test_unicode_search_value_multiple(self):
         """Ensure that unicode values can be filtered for successfully."""
         record = JsonBModel.objects.create(data={"root": {"key": "'Verified ✓'"}})
 
         filt = {'root': {'key': {'_rule_type': 'containment_multiple', 'pattern': '✓'}}}
+        query = JsonBModel.objects.filter(data__jsonb=filt)
+        self.assertEqual(list(query), [record])
+
+    def test_unicode_search_key(self):
+        """Ensure that unicode keys can be filtered on successfully."""
+        record = JsonBModel.objects.create(data={"root": {"✓": "'Verified'"}})
+
+        filt = {'root': {'✓': {'_rule_type': 'containment', 'pattern': 'Verified'}}}
+        query = JsonBModel.objects.filter(data__jsonb=filt)
+        self.assertEqual(list(query), [record])
+
+    def test_unicode_search_key_multiple(self):
+        """Ensure that unicode keys can be filtered on successfully."""
+        record = JsonBModel.objects.create(data={"root": {"✓": "'Verified'"}})
+
+        filt = {'root': {'✓': {'_rule_type': 'containment_multiple', 'pattern': 'Verified'}}}
         query = JsonBModel.objects.filter(data__jsonb=filt)
         self.assertEqual(list(query), [record])

--- a/tests/jsonb_field_testing/tests.py
+++ b/tests/jsonb_field_testing/tests.py
@@ -440,3 +440,29 @@ class JsonBFilterTests(TestCase):
         filt = {'root': {'✓': {'_rule_type': 'containment_multiple', 'pattern': 'Verified'}}}
         query = JsonBModel.objects.filter(data__jsonb=filt)
         self.assertEqual(list(query), [record])
+
+    def test_split_search_pattern_single_words(self):
+        result = FilterTree.split_search_pattern('hello world')
+        self.assertEqual(result, ['hello', 'world'])
+
+    def test_split_search_pattern_double_quoted_words(self):
+        result = FilterTree.split_search_pattern('"hello world"')
+        self.assertEqual(result, ['hello world'])
+
+    def test_split_search_pattern_single_quoted_words(self):
+        result = FilterTree.split_search_pattern("'hello world'")
+        self.assertEqual(result, ['hello world'])
+
+    def test_split_search_pattern_mixed_words(self):
+        result = FilterTree.split_search_pattern('the "hello world" message')
+        self.assertEqual(result, ['the', 'hello world', 'message'])
+
+    def test_split_search_pattern_unpaired_quote_front(self):
+        result = FilterTree.split_search_pattern('"hello world')
+        # The unpaired quote is trimmed off
+        self.assertEqual(result, ['hello', 'world'])
+
+    def test_split_search_pattern_unpaired_quote_trail(self):
+        result = FilterTree.split_search_pattern('hello world"')
+        # The unpaired quote is trimmed off
+        self.assertEqual(result, ['hello', 'world'])

--- a/tests/jsonb_field_testing/tests.py
+++ b/tests/jsonb_field_testing/tests.py
@@ -391,3 +391,28 @@ class JsonBFilterTests(TestCase):
         filt3 = {"Object Details":{"Severity":{"pattern":"fat","_rule_type":"containment"}}}
         query3 = JsonBModel.objects.filter(data__jsonb=filt3)
         self.assertEqual(query3.count(), 1)
+
+    def test_tree_unicode(self):
+        filt = {'key': {'_rule_type': 'containment', 'pattern': '✓'}}
+        tree = FilterTree(filt, 'data')
+        # Method should not raise an exception
+        val = tree.sql()
+        self.assertIsNotNone(val)
+
+    def test_tree_text_similarity_filter_unicode(self):
+        # Method should not raise an exception
+        val = FilterTree.text_similarity_filter(['key'], '✓', path_multiple=False)
+        self.assertIsNotNone(val)
+
+    def test_tree_text_similarity_filter_unicode_path_multiple(self):
+        # Method should not raise an exception
+        val = FilterTree.text_similarity_filter(['root', 'key'], '✓', path_multiple=True)
+        self.assertIsNotNone(val)
+
+    def test_unicode_search(self):
+        """Ensure that unicode values can be filtered for successfully."""
+        record = JsonBModel.objects.create(data={"root": {"key": "'Verified ✓'"}})
+
+        filt = {'root': {'key': {'_rule_type': 'containment_multiple', 'pattern': '✓'}}}
+        query = JsonBModel.objects.filter(data__jsonb=filt)
+        self.assertEqual(list(query), [record])


### PR DESCRIPTION
## Overview
This addresses a pair of exceptions that would occur when filtering for records with non-ASCII characters. The `shlex` library, a command line parsing utility, was used to split a search parameter into individual words while maintaining quoted substrings, but the `split()` method itself appears to not be Unicode safe in Python 2.7.15, and would result in an unhandled exception:
```
File "/usr/local/lib/python2.7/site-packages/django/db/models/sql/compiler.py" in compile
  373.             sql, params = node.as_sql(self, self.connection)

File "/usr/local/lib/python2.7/site-packages/grout/lookups.py" in as_sql
  396.         return FilterTree(tree, field).sql()

File "/usr/local/lib/python2.7/site-packages/grout/lookups.py" in sql
  104.                 for pattern in shlex.split(rule['pattern']):

File "/usr/local/lib/python2.7/shlex.py" in split
  275.     lex = shlex(s, posix=posix)

File "/usr/local/lib/python2.7/shlex.py" in __init__
  25.             instream = StringIO(instream)

UnicodeEncodeError: 'ascii' codec can't encode character u'\u2713' in position 0: ordinal not in range(128)
```

Suggestions were that this could be addressed by using `.encode()` on the input string, but this did not work as desired and caused other exceptions. This takes the route of using regular expressions to parse the quoted string using the suggested regex [from this StackOverflow answer](https://stackoverflow.com/a/5696141), modified to allow single and double quote usage.

Additionally, after addressing this error an additional error was uncovered in using `.format()` on a `str` literal in Python 2. `from __future__ import unicode_literals` was added to address this, and tests were added to cover possible failure cases for Unicode values.

### Checklist

- [x] PR has a descriptive title
- n/a If this PR makes breaking changes, I have updated CHANGELOG.md describing the changes
- [x] I have checked the README and made any necessary updates to documentation 

## Testing Instructions
- Tests should pass

(DRIVER specific)
- In DRIVER, edit `app/requirements.txt` and replace the line `grout==2.0.0` with `git+https://github.com/azavea/grout/@bugfix/unicode-filter#egg=grout`
- Provision the `app` VM
- In the web view, create a record using a non-ASCII character in its description such as `✓`
- Search for that character
  - The record should appear

## Related issues

Closes [PT162610919](https://www.pivotaltracker.com/story/show/162610919)
